### PR TITLE
setup: Make spark an extra-dependency

### DIFF
--- a/databricks/koala/__init__.py
+++ b/databricks/koala/__init__.py
@@ -13,6 +13,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+
+def assert_pyspark_version():
+    import logging
+    pyspark_ver = None
+    try:
+        import pyspark
+    except ImportError as err:
+        raise ImportError('Unable to import pyspark - consider doing a pip install with [spark] '
+                          'extra to install pyspark with pip')
+    else:
+        pyspark_ver = getattr(pyspark, '__version__')
+        if pyspark_ver is None or pyspark_ver < '2.4':
+            logging.warn('Found pyspark version "{}" installed. pyspark>=2.4.0 is recommended.'
+                         .format(pyspark_ver if pyspark_ver is not None else '<unknown version>'))
+
+
+assert_pyspark_version()
+
 from .utils import *
 from .namespace import *
 from .typing import Col, pandas_wrap

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@
 
 from setuptools import setup
 
+
 install_requires = [
     'pandas>=0.23',
     'decorator',

--- a/setup.py
+++ b/setup.py
@@ -18,15 +18,20 @@
 
 from setuptools import setup
 
+install_requires = [
+    'pandas>=0.23',
+    'decorator',
+    'pyarrow>=0.10,<0.11',  # See https://github.com/databricks/spark-pandas/issues/26
+]
+
 setup(
     name='databricks-koala',
     version='0.0.5',
     packages=['databricks', 'databricks.koala', 'databricks.koala._dask_stubs'],
-    install_requires=[
-        'pyspark>=2.4.0',
-        'pandas>=0.23',
-        'decorator',
-        'pyarrow>=0.10,<0.11'],  # See https://github.com/databricks/spark-pandas/issues/26
+    extras_require={
+        'spark': ['pyspark>=2.4.0'],
+    },
+    install_requires=install_requires,
     author="Timothy Hunter",
     author_email="tim@databricks.com",
     license='http://www.apache.org/licenses/LICENSE-2.0',


### PR DESCRIPTION
Spark is installed in many different ways in an environment.
Sometimes using Cloudera parcels, homebrew, binary zips, etc.

Getting the pypi spark package can make it complicated
as it is pulled during a pip install and can cause multiple
sparks to be installed by mistake, and even confuse the configs
to use - potentially breaking a system.

Move spark dependency in an extra in case a user needs us to
use pip to install spark for them. But in general avoid that.