### PR TITLE
_Frame: Add abs() for Series and DataFrame

### DIFF
--- a/databricks/koala/structures.py
+++ b/databricks/koala/structures.py
@@ -146,6 +146,15 @@ class _Frame(object):
     def max(self):
         return _reduce_spark(self, F.max)
 
+    @derived_from(pd.DataFrame)
+    def abs(self):
+        """
+        Return a Series/DataFrame with absolute numeric value of each element.
+
+        :return: :class:`Series` or :class:`DataFrame` with the absolute value of each element.
+        """
+        return _spark_col_apply(self, F.abs)
+
     def compute(self):
         """Alias of `toPandas()` to mimic dask for easily porting tests."""
         return self.toPandas()
@@ -672,6 +681,18 @@ def _reassign_jdf(target_df: DataFrame, new_df: DataFrame):
     # Reset the cached variables
     target_df._schema = None
     target_df._lazy_rdd = None
+
+
+def _spark_col_apply(col_or_df, sfun):
+    """
+    Performs a function to all cells on a dataframe, the function being a known sql function.
+    """
+    if isinstance(col_or_df, Column):
+        return sfun(col_or_df)
+    assert isinstance(col_or_df, DataFrame)
+    df = col_or_df
+    df = df._spark_select([sfun(df[col]).alias(col) for col in df.columns])
+    return df
 
 
 def _reduce_spark(col_or_df, sfun):

--- a/databricks/koala/tests/test_dataframe.py
+++ b/databricks/koala/tests/test_dataframe.py
@@ -217,6 +217,17 @@ class DataFrameTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(pd.to_datetime(s, infer_datetime_format=True),
                        pyspark.to_datetime(ds, infer_datetime_format=True))
 
+    def test_abs(self):
+        df = pd.DataFrame({'A': [1, -2, 3, -4, 5],
+                           'B': [1., -2, 3, -4, 5],
+                           'C': [-6., -7, -8, -9, 10],
+                           'D': ['a', 'b', 'c', 'd', 'e']})
+        ddf = self.spark.from_pandas(df)
+        self.assert_eq(ddf.A.abs(), df.A.abs())
+        self.assert_eq(ddf.B.abs(), df.B.abs())
+        self.assert_eq(ddf.select('B', 'C').abs(), df[['B', 'C']].abs())
+        # self.assert_eq(ddf.select('A', 'B').abs(), df[['A', 'B']].abs())
+
 
 if __name__ == "__main__":
     try:


### PR DESCRIPTION
A DataFrame.abs() will go through all columns and apply abs()
on all the columns.

Minor differences:
 - pd.DataFrame.abs() on int,float converts both columns to float
   Here it retains the int type.
 - pd.DataFrame.abs() on str or array throws error.
   Here it will return a None for string. But throw an error for array.