### PR TITLE
[55] SparkDataFrameLocator: Allow locator with no index

### DIFF
--- a/databricks/koala/selection.py
+++ b/databricks/koala/selection.py
@@ -114,7 +114,12 @@ class SparkDataFrameLocator(object):
         elif isinstance(rows_sel, slice):
             if rows_sel.step is not None:
                 raiseNotImplemented("Cannot use step with Spark.")
-            if len(self.df._index_columns) == 1:
+            if rows_sel == slice(None):
+                # If slice is None - select everything, so nothing to do
+                pass
+            elif len(self.df._index_columns) == 0:
+                raiseNotImplemented("Cannot use slice for Spark if no index provided.")
+            elif len(self.df._index_columns) == 1:
                 start = rows_sel.start
                 stop = rows_sel.stop
 

--- a/databricks/koala/tests/test_dataframe.py
+++ b/databricks/koala/tests/test_dataframe.py
@@ -50,13 +50,20 @@ class DataFrameTest(ReusedSQLTestCase, TestUtils):
         self.assert_eq(d.columns, pd.Index(['a', 'b']))
 
         self.assert_eq(d[d['b'] > 2], full[full['b'] > 2])
-        # TODO: self.assert_eq(d[['a', 'b']], full[['a', 'b']])
+        self.assert_eq(d[['a', 'b']], full[['a', 'b']])
         self.assert_eq(d.a, full.a)
         # TODO: assert d.b.mean().compute() == full.b.mean()
         # TODO: assert np.allclose(d.b.var().compute(), full.b.var())
         # TODO: assert np.allclose(d.b.std().compute(), full.b.std())
 
         assert repr(d)
+
+        df = pd.DataFrame({
+            'a': [1, 2, 3, 4, 5, 6, 7, 8, 9],
+            'b': [4, 5, 6, 3, 2, 1, 0, 0, 0],
+        })
+        ddf = self.spark.createDataFrame(df)
+        self.assert_eq(df[['a', 'b']], ddf[['a', 'b']])
 
     def test_head_tail(self):
         d = self.df

--- a/databricks/koala/tests/test_indexing.py
+++ b/databricks/koala/tests/test_indexing.py
@@ -134,6 +134,7 @@ class IndexingTest(ReusedSQLTestCase):
         self.assert_eq(d.loc[:8], full.loc[:8])
         self.assert_eq(d.loc[3:], full.loc[3:])
         self.assert_eq(d.loc[[5]], full.loc[[5]])
+        self.assert_eq(d.loc[:], full.loc[:])
 
         # TODO?: self.assert_eq(d.loc[[3, 4, 1, 8]], full.loc[[3, 4, 1, 8]])
         # TODO?: self.assert_eq(d.loc[[3, 4, 1, 9]], full.loc[[3, 4, 1, 9]])
@@ -171,6 +172,38 @@ class IndexingTest(ReusedSQLTestCase):
 
         self.assert_eq(d.loc[d.a % 2 == 0], full.loc[full.a % 2 == 0])
 
+    def test_loc_noindex(self):
+        d = self.df
+        d = d.reset_index()
+        full = self.full
+        full = full.reset_index()
+
+        self.assert_eq(d[['a']], full[['a']])
+
+        self.assert_eq(d.loc[:], full.loc[:])
+        self.assertRaises(NotImplementedError, lambda: d.loc[5:5])
+
+    def test_loc_multiindex(self):
+        d = self.df
+        d = d.set_index('b', append=True)
+        full = self.full
+        full = full.set_index('b', append=True)
+
+        self.assert_eq(d[['a']], full[['a']])
+
+        self.assert_eq(d.loc[:], full.loc[:])
+        self.assertRaises(NotImplementedError, lambda: d.loc[5:5])
+
+    def test_loc2d_multiindex(self):
+        d = self.df
+        d = d.set_index('b', append=True)
+        full = self.full
+        full = full.set_index('b', append=True)
+
+        self.assert_eq(d.loc[:, :], full.loc[:, :])
+        self.assert_eq(d.loc[:, 'a'], full.loc[:, 'a'])
+        self.assertRaises(NotImplementedError, lambda: d.loc[5:5, 'a'])
+
     def test_loc2d(self):
         d = self.df
         full = self.full
@@ -180,6 +213,7 @@ class IndexingTest(ReusedSQLTestCase):
         self.assert_eq(d.loc[[5], 'a'], full.loc[[5], 'a'])
         self.assert_eq(d.loc[5:5, ['a']], full.loc[5:5, ['a']])
         self.assert_eq(d.loc[[5], ['a']], full.loc[[5], ['a']])
+        self.assert_eq(d.loc[:, :], full.loc[:, :])
 
         self.assert_eq(d.loc[3:8, 'a'], full.loc[3:8, 'a'])
         self.assert_eq(d.loc[:8, 'a'], full.loc[:8, 'a'])


### PR DESCRIPTION
Even if no index is provided, if there is no slice selection
provided in the Locator - it should work. As the index
is not required and can be anything.

Fixes https://github.com/databricks/spark-pandas/issues/55