### PR TITLE
Miscellaneous cleanups (avoid deprecated method, unused lines, styles)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,21 +1,6 @@
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
 # Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
 
-# User-specific stuff:
-.idea/workspace.xml
-.idea/tasks.xml
-.idea/dictionaries
-.idea/vcs.xml
-.idea/jsLibraryMappings.xml
-
-# Sensitive or high-churn files:
-.idea/dataSources.ids
-.idea/dataSources.xml
-.idea/dataSources.local.xml
-.idea/sqlDataSources.xml
-.idea/dynamic.xml
-.idea/uiDesigner.xml
-
 ## File-based project format:
 *.iws
 

--- a/databricks/koala/__init__.py
+++ b/databricks/koala/__init__.py
@@ -20,14 +20,15 @@ def assert_pyspark_version():
     pyspark_ver = None
     try:
         import pyspark
-    except ImportError as err:
+    except ImportError:
         raise ImportError('Unable to import pyspark - consider doing a pip install with [spark] '
                           'extra to install pyspark with pip')
     else:
         pyspark_ver = getattr(pyspark, '__version__')
         if pyspark_ver is None or pyspark_ver < '2.4':
-            logging.warn('Found pyspark version "{}" installed. pyspark>=2.4.0 is recommended.'
-                         .format(pyspark_ver if pyspark_ver is not None else '<unknown version>'))
+            logging.warning(
+                'Found pyspark version "{}" installed. pyspark>=2.4.0 is recommended.'
+                .format(pyspark_ver if pyspark_ver is not None else '<unknown version>'))
 
 
 assert_pyspark_version()

--- a/databricks/koala/groups.py
+++ b/databricks/koala/groups.py
@@ -17,8 +17,6 @@
 """
 A wrapper for GroupedData to behave similar to pandas.
 """
-import sys
-
 from pyspark.sql.types import StructType
 
 from ._dask_stubs.compatibility import string_types

--- a/databricks/koala/metadata.py
+++ b/databricks/koala/metadata.py
@@ -17,8 +17,6 @@
 """
 A metadata to manage indexes.
 """
-import sys
-
 import pandas as pd
 
 from ._dask_stubs.compatibility import string_types

--- a/databricks/koala/utils.py
+++ b/databricks/koala/utils.py
@@ -23,7 +23,7 @@ from decorator import decorator
 import types
 import logging
 
-from .structures import *
+from .structures import PandasLikeDataFrame, PandasLikeSeries, SparkSessionPatches
 from . import namespace
 
 logger = logging.getLogger('spark')

--- a/dev/tox.ini
+++ b/dev/tox.ini
@@ -16,6 +16,5 @@
 [pycodestyle]
 ignore=E226,E241,E305,E402,E722,E731,E741,W503,W504
 max-line-length=100
-exclude=cloudpickle.py,heapq3.py,shared.py,python/docs/conf.py,work/*/*.py,python/.eggs/*,dist/*
 [pydocstyle]
 ignore=D100,D101,D102,D103,D104,D105,D106,D107,D200,D201,D202,D203,D204,D205,D206,D207,D208,D209,D210,D211,D212,D213,D214,D215,D300,D301,D302,D400,D401,D402,D403,D404,D405,D406,D407,D408,D409,D410,D411,D412,D413,D414


### PR DESCRIPTION
This PR fixes:

1. Duplicated `.idea/...` in `.gitignore`. That's covered by `.idea/`
2. `logging.warn` is deprecated from Python 3.3 as of `logging.warning`
3. Avoid wildcard imports
4. Remove `exclude` in `tox.ini` (that looks copied from Apache Spark side)
5. Remove unused imports.