### PR TITLE
Fixed 3 issues of type: PYTHON_E402 throughout 1 file in repo.

### DIFF
--- a/databricks/koala/__init__.py
+++ b/databricks/koala/__init__.py
@@ -15,6 +15,9 @@
 #
 
 
+from .utils import *
+from .namespace import *
+from .typing import Col, pandas_wrap
 def assert_pyspark_version():
     import logging
     pyspark_ver = None
@@ -33,9 +36,6 @@ def assert_pyspark_version():
 
 assert_pyspark_version()
 
-from .utils import *
-from .namespace import *
-from .typing import Col, pandas_wrap
 
 __all__ = ['patch_spark', 'read_csv', 'Col', 'pandas_wrap']
 


### PR DESCRIPTION
PYTHON_E402: 'module level import not at top of file'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.