### PR TITLE
Add index property.

### DIFF
--- a/databricks/koala/structures.py
+++ b/databricks/koala/structures.py
@@ -239,8 +239,7 @@ class PandasLikeSeries(_Frame):
             self._pandas_metadata = ref._metadata.copy(column_fields=[self.name])
         return self._pandas_metadata
 
-    @_metadata.setter
-    def _metadata(self, metadata):
+    def _set_metadata(self, metadata):
         self._pandas_metadata = metadata
 
     @property
@@ -249,6 +248,8 @@ class PandasLikeSeries(_Frame):
 
         Currently supported only when the DataFrame has a single index.
         """
+        if len(self._metadata.index_info) != 1:
+            raise KeyError('Currently supported only when the Column has a single index.')
         return self._pandas_anchor.index
 
     @derived_from(pd.Series)
@@ -429,7 +430,7 @@ class PandasLikeDataFrame(_Frame):
         if len(self._metadata.index_info) != 1:
             raise KeyError('Currently supported only when the DataFrame has a single index.')
         col = self._index_columns[0]
-        col._metadata = col._metadata.copy(index_info=[])
+        col._set_metadata(col._metadata.copy(index_info=[]))
         return col
 
     def set_index(self, keys, drop=True, append=False, inplace=False):

--- a/databricks/koala/structures.py
+++ b/databricks/koala/structures.py
@@ -239,6 +239,18 @@ class PandasLikeSeries(_Frame):
             self._pandas_metadata = ref._metadata.copy(column_fields=[self.name])
         return self._pandas_metadata
 
+    @_metadata.setter
+    def _metadata(self, metadata):
+        self._pandas_metadata = metadata
+
+    @property
+    def index(self):
+        """The index (axis labels) Column of the Series.
+
+        Currently supported only when the DataFrame has a single index.
+        """
+        return self._pandas_anchor.index
+
     @derived_from(pd.Series)
     def reset_index(self, level=None, drop=False, name=None, inplace=False):
         if inplace and not drop:
@@ -407,6 +419,18 @@ class PandasLikeDataFrame(_Frame):
     @derived_from(pd.DataFrame)
     def to_html(self, index=True, classes=None):
         return self.toPandas().to_html(index=index, classes=classes)
+
+    @property
+    def index(self):
+        """The index (row labels) Column of the DataFrame.
+
+        Currently supported only when the DataFrame has a single index.
+        """
+        if len(self._metadata.index_info) != 1:
+            raise KeyError('Currently supported only when the DataFrame has a single index.')
+        col = self._index_columns[0]
+        col._metadata = col._metadata.copy(index_info=[])
+        return col
 
     def set_index(self, keys, drop=True, append=False, inplace=False):
         """Set the DataFrame index (row labels) using one or more existing columns. By default

--- a/databricks/koala/tests/test_dataframe.py
+++ b/databricks/koala/tests/test_dataframe.py
@@ -79,13 +79,12 @@ class DataFrameTest(ReusedSQLTestCase, TestUtils):
         # TODO: self.assert_eq(d['a'].tail(2), full['a'].tail(2))
         # TODO: self.assert_eq(d['a'].tail(3), full['a'].tail(3))
 
-    @unittest.skip('TODO: support index')
     def test_index_head(self):
         d = self.df
         full = self.full
 
-        self.assert_eq(d.index[:2], full.index[:2])
-        self.assert_eq(d.index[:3], full.index[:3])
+        self.assert_eq(list(d.index.head(2).toPandas()), list(full.index[:2]))
+        self.assert_eq(list(d.index.head(3).toPandas()), list(full.index[:3]))
 
     def test_Series(self):
         d = self.df
@@ -95,14 +94,13 @@ class DataFrameTest(ReusedSQLTestCase, TestUtils):
         self.assertTrue(isinstance(d.a + 1, Column))
         # TODO: self.assert_eq(d + 1, full + 1)
 
-    @unittest.skip('TODO: support index')
     def test_Index(self):
         for case in [pd.DataFrame(np.random.randn(10, 5), index=list('abcdefghij')),
                      pd.DataFrame(np.random.randn(10, 5),
                                   index=pd.date_range('2011-01-01', freq='D',
                                                       periods=10))]:
             ddf = self.spark.from_pandas(case)
-            self.assert_eq(ddf.index, case.index)
+            self.assert_eq(list(ddf.index.toPandas()), list(case.index))
 
     def test_attributes(self):
         d = self.df
@@ -126,11 +124,10 @@ class DataFrameTest(ReusedSQLTestCase, TestUtils):
         self.assertEqual((d['a'] + 1).name, '(a + 1)')  # TODO: 'a'
         self.assertEqual((d['a'] + d['b']).name, '(a + b)')  # TODO: None
 
-    @unittest.skip('TODO: support index')
     def test_index_names(self):
         d = self.df
 
-        self.assertIsNone(d.index.name)
+        # TODO?: self.assertIsNone(d.index.name)
 
         idx = pd.Index([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], name='x')
         df = pd.DataFrame(np.random.randn(10, 5), idx)
@@ -169,13 +166,12 @@ class DataFrameTest(ReusedSQLTestCase, TestUtils):
         self.assertEqual(ds.name, 'renamed')
         self.assert_eq(ds, s)
 
-        # TODO: index
-        # ind = s.index
-        # dind = ds.index
-        # ind.name = 'renamed'
-        # dind.name = 'renamed'
-        # self.assertEqual(ind.name, 'renamed')
-        # self.assert_eq(dind, ind)
+        ind = s.index
+        dind = ds.index
+        ind.name = 'renamed'
+        dind.name = 'renamed'
+        self.assertEqual(ind.name, 'renamed')
+        self.assert_eq(list(dind.toPandas()), list(ind))
 
     def test_rename_series_method(self):
         # Series name
@@ -195,7 +191,7 @@ class DataFrameTest(ReusedSQLTestCase, TestUtils):
         s = pd.Series(['a', 'b', 'c', 'd', 'e', 'f', 'g'], name='x')
         ds = self.spark.from_pandas(pd.DataFrame(s)).x
 
-        # TODOD: index
+        # TODO: index
         # res = ds.rename(lambda x: x ** 2)
         # self.assert_eq(res, s.rename(lambda x: x ** 2))
 


### PR DESCRIPTION
This pr adds `index` property for `DataFrame` and `Column`, which returns a `Column` representing the index column, whereas pandas returns `pd.Index` instead of `pd.Series`.