### PR TITLE
Add Sphinx documentation generation foundation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ __pycache__/
 *.log
 
 .DS_Store
+
+# Sphinx build
+_build

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,12 +14,12 @@ matrix:
     - python: "3.5"
       env:
         - SPARK_VERSION=2.3.3
-        - PANDAS_VERSION=0.24.2
+        - PANDAS_VERSION=0.23.4
         - PYARROW_VERSION=0.10.0
     - python: "3.6"
       env:
         - SPARK_VERSION=2.4.1
-        - PANDAS_VERSION=0.23.4
+        - PANDAS_VERSION=0.24.2
         - PYARROW_VERSION=0.10.0
 
 before_install:
@@ -44,7 +44,9 @@ install:
   - conda info -a
 
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -c conda-forge -q -n test-environment python=$TRAVIS_PYTHON_VERSION nose==1.3.7 pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION
+  - conda config --env --add pinned_packages pandas==$PANDAS_VERSION
+  - conda config --env --add pinned_packages pyarrow==$PYARROW_VERSION
+  - conda create -c conda-forge -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - conda activate test-environment
   - conda install -c conda-forge --yes --file requirements-dev.txt
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - python: "3.5"
       env:
         - SPARK_VERSION=2.3.3
-        - PANDAS_VERSION=0.23.0
+        - PANDAS_VERSION=0.24.2
         - PYARROW_VERSION=0.10.0
     - python: "3.6"
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     - python: "3.5"
       env:
         - SPARK_VERSION=2.3.3
-        - PANDAS_VERSION=0.19.2
+        - PANDAS_VERSION=0.23.0
         - PYARROW_VERSION=0.10.0
     - python: "3.6"
       env:
@@ -44,13 +44,15 @@ install:
   - conda info -a
 
   # Replace dep1 dep2 ... with your dependencies
-  - conda create -c conda-forge -q -n test-environment python=$TRAVIS_PYTHON_VERSION nose==1.3.7 flake8>=3.5.0 pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION decorator
+  - conda create -c conda-forge -q -n test-environment python=$TRAVIS_PYTHON_VERSION nose==1.3.7 pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION
   - conda activate test-environment
+  - conda install -c conda-forge --yes -n test-environment --file requirements-dev.txt
 
   - conda list
 
 before_script:
+  - export SPARK_HOME="$HOME/.cache/spark-versions/spark-$SPARK_VERSION-bin-hadoop2.7"
   - ./dev/lint-python
 
 script:
-  - SPARK_HOME="$HOME/.cache/spark-versions/spark-$SPARK_VERSION-bin-hadoop2.7" ./dev/run-tests.sh
+  - ./dev/run-tests.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ install:
   # Replace dep1 dep2 ... with your dependencies
   - conda create -c conda-forge -q -n test-environment python=$TRAVIS_PYTHON_VERSION nose==1.3.7 pandas==$PANDAS_VERSION pyarrow==$PYARROW_VERSION
   - conda activate test-environment
-  - conda install -c conda-forge --yes -n test-environment --file requirements-dev.txt
+  - conda install -c conda-forge --yes --file requirements-dev.txt
 
   - conda list
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ Pandas is the de facto standard (single-node) dataframe implementation in Python
 ## Table of Contents <!-- omit in toc -->
 - [Dependencies](#dependencies)
 - [Get Started](#get-started)
-- [Documentation](#documentation)
 - [Project Status](#project-status)
 - [Development Guide](#development-guide)
   - [Environment Setup](#environment-setup)
   - [Running Tests](#running-tests)
+  - [Building Documentation](#building-documentation)
   - [Contributions](#contributions)
   - [Coding Conventions](#coding-conventions)
   - [Release Instructions](#release-instructions)
@@ -62,10 +62,6 @@ df.columns = ['x', 'y', 'z1']
 df['x2'] = df.x * df.x
 ```
 
-## Documentation
-
-Coming soon. Generating API docs for this project is the highest priority item we are working on.
-
 
 ## Project Status
 
@@ -92,7 +88,7 @@ We recommend setting up a Conda environment for development:
 ```bash
 conda create --name koalas-dev-env python=3.6
 conda activate koalas-dev-env
-conda install -c conda-forge pyspark=2.4 pandas pyarrow=0.10 decorator flake8 nose
+conda install -c conda-forge --yes -n test-environment --file requirements-dev.txt
 pip install -e .  # installs koalas from current checkout
 ```
 
@@ -117,6 +113,17 @@ To run a specific test method:
 ```bash
 python databricks/koalas/tests/test_dataframe.py DataFrameTest.test_Dataframe
 ```
+
+### Building Documentation
+
+To build documentation via Sphinx:
+
+```bash
+cd docs && make clean html
+```
+
+It generates HTMLs under `docs/_build/html` directory. Open `docs/_build/html/index.html` to check if documenation is built properly.
+
 
 ### Contributions
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Pandas is the de facto standard (single-node) dataframe implementation in Python
 ## Table of Contents <!-- omit in toc -->
 - [Dependencies](#dependencies)
 - [Get Started](#get-started)
+- [Documentation](#documentation)
 - [Project Status](#project-status)
 - [Development Guide](#development-guide)
   - [Environment Setup](#environment-setup)
@@ -61,6 +62,10 @@ df.columns = ['x', 'y', 'z1']
 # Do some operations in place:
 df['x2'] = df.x * df.x
 ```
+
+## Documentation
+
+Coming soon. Generating API docs for this project is the highest priority item we are working on.
 
 
 ## Project Status

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ We recommend setting up a Conda environment for development:
 ```bash
 conda create --name koalas-dev-env python=3.6
 conda activate koalas-dev-env
-conda install -c conda-forge --yes -n test-environment --file requirements-dev.txt
+conda install -c conda-forge --yes --file requirements-dev.txt
 pip install -e .  # installs koalas from current checkout
 ```
 

--- a/databricks/koalas/__init__.py
+++ b/databricks/koalas/__init__.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+from databricks.koalas.version import __version__
+
 
 def assert_pyspark_version():
     import logging

--- a/databricks/koalas/version.py
+++ b/databricks/koalas/version.py
@@ -1,0 +1,17 @@
+#
+# Copyright (C) 2019 Databricks, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+__version__ = '0.0.6'

--- a/dev/lint-python
+++ b/dev/lint-python
@@ -27,6 +27,13 @@ MINIMUM_PYCODESTYLE="2.4.0"
 
 SPHINX_BUILD="sphinx-build"
 
+# Sphinx will import Koalas out of the box. Importing Koalas requires to have
+# PySpark currently.
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+if [ -n "$SPARK_HOME" ]; then
+    source $DIR/env_setup.sh
+fi
+
 function compile_python_test {
     local COMPILE_STATUS=
     local COMPILE_REPORT=
@@ -214,7 +221,7 @@ function sphinx_test {
     fi
 
     echo "starting $SPHINX_BUILD tests..."
-    pushd python/docs &> /dev/null
+    pushd docs &> /dev/null
     make clean &> /dev/null
     # Treat warnings as errors so we stop correctly
     SPHINX_REPORT=$( (SPHINXOPTS="-a -W" make html) 2>&1)

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,21 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line.
+SPHINXOPTS    =
+SPHINXBUILD   = sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+export PYTHONPATH := $(realpath ..):$(PYTHONPATH)
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,90 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# This file only contains a selection of the most common options. For a full
+# list see the documentation:
+# http://www.sphinx-doc.org/en/master/config
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+
+import os
+import sys
+from databricks import koalas
+sys.path.insert(0, os.path.abspath('.'))
+
+
+# -- Project information -----------------------------------------------------
+
+project = 'Koalas'
+copyright = '2019, Databricks'
+author = 'The Koalas Team'
+
+# The full version, including alpha/beta/rc tags
+release = os.environ.get('RELEASE_VERSION', koalas.__version__)
+
+
+# -- General configuration ---------------------------------------------------
+
+# If your documentation needs a minimal Sphinx version, state it here.
+needs_sphinx = '1.2'
+
+# Add any Sphinx extension module names here, as strings. They can be
+# extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
+# ones.
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.viewcode',
+    'numpydoc',  # handle NumPy documentation formatted docstrings. Needs to install
+    'nbsphinx',  # Jupyter Notebook. Needs to install
+]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+# The name of the Pygments (syntax highlighting) style to use.
+pygments_style = 'sphinx'
+
+# The master toctree document.
+master_doc = 'index'
+
+
+# -- Options for auto output -------------------------------------------------
+
+autoclass_content = 'both'
+
+
+# -- Options for HTML output -------------------------------------------------
+
+# The theme to use for HTML and HTML Help pages.  See the documentation for
+# a list of builtin themes.
+#
+html_theme = 'nature'
+
+# Add any paths that contain custom static files (such as style sheets) here,
+# relative to this directory. They are copied after the builtin static files,
+# so a file named "default.css" will overwrite the builtin "default.css".
+html_static_path = ['_static']
+
+# If false, no index is generated.
+html_use_index = False
+
+# If false, no module index is generated.
+html_domain_indices = False
+
+
+# -- Options for manual page output ---------------------------------------
+
+# One entry per manual page. List of tuples
+# (source start file, name, description, authors, manual section).
+man_pages = [
+    ('index', 'databricks.koalas', u'databricks.koalas Documentation',
+     [u'Author'], 1)
+]

--- a/docs/databricks.koalas.rst
+++ b/docs/databricks.koalas.rst
@@ -1,0 +1,51 @@
+databricks.koalas package
+==========================
+
+databricks.koalas.exceptions module
+-----------------------------------
+
+.. automodule:: databricks.koalas.exceptions
+    :members:
+    :undoc-members:
+    :inherited-members:
+
+databricks.koalas.frame module
+-----------------------------------
+
+.. automodule:: databricks.koalas.frame
+    :members:
+    :undoc-members:
+    :inherited-members:
+
+databricks.koalas.groups module
+-----------------------------------
+
+.. automodule:: databricks.koalas.groups
+    :members:
+    :undoc-members:
+    :inherited-members:
+
+databricks.koalas.namespace module
+-----------------------------------
+
+.. automodule:: databricks.koalas.namespace
+    :members:
+    :undoc-members:
+    :inherited-members:
+
+databricks.koalas.series module
+-----------------------------------
+
+.. automodule:: databricks.koalas.series
+    :members:
+    :undoc-members:
+    :inherited-members:
+
+databricks.koalas.session module
+-----------------------------------
+
+.. automodule:: databricks.koalas.session
+    :members:
+    :undoc-members:
+    :inherited-members:
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,17 @@
+.. Koalas' documentation master file, created by
+   sphinx-quickstart on Thu Apr 18 14:08:15 2019.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Koalas' documentation!
+============================================
+
+.. toctree::
+    :maxdepth: 2
+
+    databricks.koalas
+
+Indices and tables
+==================
+
+* :ref:`search`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS%
+
+:end
+popd

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,9 @@
+nose==1.3.7
+flake8>=3.5.0
+pandas>=0.23
+pyarrow>=0.10,<0.11
+decorator
+sphinx==2.0.1
+nbsphinx=0.4.2
+numpydoc=0.8.0
+

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@
 # limitations under the License.
 #
 
+import sys
 from setuptools import setup
 
 DESCRIPTION = "Pandas DataFrame API on Apache Spark"
@@ -35,9 +36,17 @@ With this package, data scientists can:
   and with Spark (distributed datasets).
 """
 
+try:
+    exec(open('databricks/koalas/version.py').read())
+except IOError:
+    print("Failed to load Koalas version file for packaging. You must be in Koalas root dir.",
+          file=sys.stderr)
+    sys.exit(-1)
+VERSION = __version__  # noqa
+
 setup(
     name='koalas',
-    version='0.0.6',
+    version=VERSION,
     packages=['databricks', 'databricks.koalas', 'databricks.koalas.dask',
               'databricks.koalas.missing'],
     extras_require={


### PR DESCRIPTION
This PR proposes to add a foundation for the documentation and API list for databricks.koalas (a.k.a Spark Pandas). This PR

1. Add `Makefile` and Sphinx configuration files to generate the documentation from docstrings.

2. Fix `.travis.xml` and `dev/lint-python` to test documentation generation.

3. Add `__version__` to `databricks.koalas.version` that is shared for `setup.py`, `conf.py` (for doc generation) and `databricks.koalas.__version__`. This hack is borrowed from PySpark approach.

4. Add `requirements-dev.txt` file so that it can be used in CI and dev guide.

5. Add some extra additional packages to generate docs that need to be installed:
    - `nbsphinx` to allow Jupyter note books. Seems needing some more works to actually use it.
    - `numpydoc` to allow `numpy` style docs (from Pandas via `derived_from`).


Note and followups:
 - It is important to address #90 before finishing the documentation generation as it decides how we document (see https://github.com/databricks/spark-pandas/pull/84#pullrequestreview-228161984)

  - We should also discuss how we're going to deal with `derived_from`. See https://github.com/databricks/spark-pandas/pull/84#discussion_r276867315




Partially addresses #87