### PR TITLE
Make run-tests.sh easier to use.

### DIFF
--- a/dev/run-tests.sh
+++ b/dev/run-tests.sh
@@ -20,7 +20,10 @@
 
 # The current directory of the script.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-source $DIR/env_setup.sh
+
+if [ -n "$SPARK_HOME" ]; then
+    source $DIR/env_setup.sh
+fi
 
 FWDIR="$( cd "$DIR"/.. && pwd )"
 cd "$FWDIR"


### PR DESCRIPTION
Prior to #86, make `run-tests.sh` easier to use.
Currently we always need to define `SPARK_HOME` but it's not needed if the package is installed with `conda` or `pip`.