### PR TITLE
Fix EtlTest test able to run everywhere

### DIFF
--- a/databricks/koalas/tests/test_etl.py
+++ b/databricks/koalas/tests/test_etl.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import os
 import unittest
 
 import pandas as pd
@@ -25,7 +26,8 @@ class EtlTest(ComparisonTestBase):
 
     @property
     def pdf(self):
-        return pd.read_csv('data/sample_stocks.csv')
+        test_dir = os.path.dirname(os.path.realpath(__file__))
+        return pd.read_csv('%s/../../../data/sample_stocks.csv' % test_dir)
 
     @compare_both
     def test_etl(self, df):


### PR DESCRIPTION
This PR proposes to make `sample_stocks` data accessed by the path based on the Python script.
This is useful when to run tests via PyCharm:

Before:
![Screen Shot 2019-04-19 at 7 09 40 PM](https://user-images.githubusercontent.com/6477701/56419885-d48c5200-62d6-11e9-9272-d2d9fe7f18c2.png)

After:

![Screen Shot 2019-04-19 at 7 09 26 PM](https://user-images.githubusercontent.com/6477701/56419884-d2c28e80-62d6-11e9-90c0-216ceccad7df.png)
