### PR TITLE
Upgrade PySpark version for travis-ci.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
         - PYARROW_VERSION=0.10.0
     - python: "3.6"
       env:
-        - SPARK_VERSION=2.4.0
+        - SPARK_VERSION=2.4.1
         - PANDAS_VERSION=0.23.4
         - PYARROW_VERSION=0.10.0
 


### PR DESCRIPTION
The PySpark `2.4.0` package is no longer available on the download mirrors.